### PR TITLE
Fix publish condition for npm-publish v4

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
     - id: publish
       uses: JS-DevTools/npm-publish@v4
     - name: Create Release
-      if: steps.publish.outputs.type != 'none'
+      if: ${{ steps.publish.outputs.type }}
       id: create_release
       uses: actions/create-release@v1
       env:


### PR DESCRIPTION
## Summary
- Change `if: steps.publish.outputs.type != 'none'` to `if: ${{ steps.publish.outputs.type }}`

npm-publish v4 outputs an empty string when the version is unchanged (v1 used `none`). The old condition was always true, causing the Create Release step to run and fail on every non-release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)